### PR TITLE
Increase SOURCE_NUM from 2 to 3

### DIFF
--- a/drivers/soc/oplus/sensor/Makefile
+++ b/drivers/soc/oplus/sensor/Makefile
@@ -1,3 +1,7 @@
+ifeq ($(strip $(TARGET_USES_LEGACY_SENSOR_DEVINFO)), true)
+ccflags-y += -DUSES_LEGACY_SENSOR_DEVINFO
+endif
+
 oplus_sensor-y := oplus_sensor_devinfo.o
 oplus_sensor-y += oplus_press_cali_info.o
 oplus_sensor-y += oplus_pad_als_info.o

--- a/drivers/soc/oplus/sensor/oplus_sensor_devinfo.h
+++ b/drivers/soc/oplus/sensor/oplus_sensor_devinfo.h
@@ -26,7 +26,13 @@
 #define REG_NUM 10
 #define PARAMETER_NUM 25
 #define FEATURE_NUM 10
+
+#ifndef USES_LEGACY_SENSOR_DEVINFO
+#define SOURCE_NUM 3
+#else
 #define SOURCE_NUM 2
+#endif
+
 #define ALGO_PARAMETER_NUM 15
 #define ALGO_FEATURE_NUM  5
 #define DEFAULT_CONFIG 0xff


### PR DESCRIPTION
This restores compatibility to the GTME firmware starting with F.07.

[Mashopy: Make SOURCE_NUM being able to be set to 2 due to SM8250 A12 firmware]

Change-Id: I7b52d15418b9a6b4a382957fdd72bc3d0a15b08e