### PR TITLE
Revert "PM: sleep: Don't allow s2idle to be used"

### DIFF
--- a/kernel/power/main.c
+++ b/kernel/power/main.c
@@ -156,8 +156,6 @@ static ssize_t mem_sleep_store(struct kobject *kobj, struct kobj_attribute *attr
 	suspend_state_t state;
 	int error;
 
-	/* Don't allow userspace to select s2idle */
-	return n;
 	error = pm_autosleep_lock();
 	if (error)
 		return error;


### PR DESCRIPTION
This reverts commit 823a815957b308fcdebc15ffe9bbc4ef7c7719a0.